### PR TITLE
Suggestions on focus only if query empty

### DIFF
--- a/cosmoz-omnitable-treenode-column.html
+++ b/cosmoz-omnitable-treenode-column.html
@@ -133,7 +133,7 @@ cosmoz-omnitable column to display a tree node
 			_showResultsOnFocus: {
 				type: Boolean,
 				value: true,
-				computed: '_computeShowResultsOnFocus(query)'
+				computed: '_computeShowResultsOnFocus(filter)'
 			},
 
 			/**
@@ -191,10 +191,6 @@ cosmoz-omnitable column to display a tree node
 		behaviors: [
 			Cosmoz.OmnitableColumnBehavior
 		],
-
-		_computeShowResultsOnFocus(query) {
-			return query ? false : true;
-		},
 
 		_computeSuggestionList(values, collator, ownerTree = this.ownerTree) {
 			if (!Array.isArray(values) || values.length === 0 || !ownerTree) {
@@ -297,8 +293,12 @@ cosmoz-omnitable column to display a tree node
 				.length;
 		},
 
-		_computeReadOnly: function (filter) {
+		_computeReadOnly(filter) {
 			return !!filter;
+		},
+
+		_computeShowResultsOnFocus(filter) {
+			return !filter;
 		},
 
 		_serializeFilter: function (filter = this.filter) {

--- a/cosmoz-omnitable-treenode-column.html
+++ b/cosmoz-omnitable-treenode-column.html
@@ -122,6 +122,16 @@ cosmoz-omnitable column to display a tree node
 				type: String,
 				computed: '_computeTooltip(filter)'
 			},
+	
+			minWidth: {
+				type: String,
+				value: '85px'
+			},
+
+			editMinWidth: {
+				type: String,
+				value: '85px'
+			},
 
 			/**
 			 * Function used to filter available items.
@@ -178,6 +188,10 @@ cosmoz-omnitable column to display a tree node
 		behaviors: [
 			Cosmoz.OmnitableColumnBehavior
 		],
+
+		_computeShowResultsOnFocus(query) {
+			return query ? false : true;
+		},
 
 		_computeSuggestionList(values, collator, ownerTree = this.ownerTree) {
 			if (!Array.isArray(values) || values.length === 0 || !ownerTree) {

--- a/cosmoz-omnitable-treenode-column.html
+++ b/cosmoz-omnitable-treenode-column.html
@@ -136,16 +136,6 @@ cosmoz-omnitable column to display a tree node
 				computed: '_computeShowResultsOnFocus(query)'
 			},
 
-			minWidth: {
-				type: String,
-				value: '85px'
-			},
-
-			editMinWidth: {
-				type: String,
-				value: '85px'
-			},
-
 			/**
 			 * Function used to filter available items.
 			 * This function is actually used by `paper-autocomplete`,

--- a/cosmoz-omnitable-treenode-column.html
+++ b/cosmoz-omnitable-treenode-column.html
@@ -33,7 +33,7 @@ cosmoz-omnitable column to display a tree node
 				value="{{ filter }}"
 				min-length="0"
 				title="[[ _tooltip ]]"
-				show-results-on-focus
+				show-results-on-focus="[[ _showResultsOnFocus ]]"
 				readonly="[[ _computeReadOnly(filter) ]]">
 				<paper-spinner-lite style="width: 20px; height: 20px;" suffix slot="suffix" active="[[ loading ]]" hidden="[[ !loading ]]"></paper-spinner-lite>
 
@@ -96,8 +96,8 @@ cosmoz-omnitable column to display a tree node
 			},
 
 			/**
-				* Name of the property used to lookup the displayed node in the tree
-				*/
+			 * Name of the property used to lookup the displayed node in the tree
+			 */
 			keyProperty: {
 				type: String,
 			},
@@ -105,6 +105,13 @@ cosmoz-omnitable column to display a tree node
 			valueProperty: {
 				type: String,
 				value: 'name'
+			},
+
+			/**
+			 * The value of the `paper-autocomplete` input.
+			 */
+			query: {
+				type: String
 			},
 
 			_collator: {
@@ -123,6 +130,12 @@ cosmoz-omnitable column to display a tree node
 				computed: '_computeTooltip(filter)'
 			},
 	
+			_showResultsOnFocus: {
+				type: Boolean,
+				value: true,
+				computed: '_computeShowResultsOnFocus(query)'
+			},
+
 			minWidth: {
 				type: String,
 				value: '85px'

--- a/test/basic.html
+++ b/test/basic.html
@@ -122,9 +122,10 @@
 			done();
 		});
 
-		test('selection readonly', function (done) {
+		test('selection readonly & showResultsOnFocus', function (done) {
 			paperAutocomplete.setOption(paperAutocomplete.source[0]);
 			assert.isTrue(paperAutocomplete.readonly);
+			assert.isFalse(paperAutocomplete.showResultsOnFocus);
 			done();
 		});
 


### PR DESCRIPTION
Set `paper-autocomplete`'s `show-results-on-focus` to true, only if there is no query (text) value.

There is still an issue when the source changes while suggestions are open. Working on it..