### PR TITLE
Fix failing test after omnitable upgrade

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -112,7 +112,7 @@
 					Polymer.Base.async(() => {
 						column = omnitable.columns[1];
 						column.ownerTree = tree;
-						paperAutocomplete = omnitable.$$('cosmoz-omnitable-header-row').elements[1].querySelector('paper-autocomplete');
+						paperAutocomplete = omnitable.$$('paper-autocomplete');
 
 						Polymer.Base.async(done, 90);
 					}, 100);


### PR DESCRIPTION
OmnitableColumnMixin applies OmnitableRepeaterMixin which used to expose `.elements`.