### PR TITLE
Adding query property notify property

### DIFF
--- a/cosmoz-omnitable-treenode-column.js
+++ b/cosmoz-omnitable-treenode-column.js
@@ -119,7 +119,8 @@ class CosmozOmnitableTreenodeColumn extends columnMixin(PolymerElement) {
 			* The value of the `paper-autocomplete` input.
 			*/
 			query: {
-				type: String
+				type: String,
+				notify: true
 			},
 
 			_collator: {


### PR DESCRIPTION
Adding query property notify property.

This property is missing, and therefore will not the connected calls get notified when the input changes.

More seems to be wrong when using this in query mode, because results are shown even if the query function gets an empty array, maybe it is caused by an uncleared list.

Issue is 21074.