### PR TITLE
fix(ownerTree): owner-tree updates are not propagated to the cosmoz-treenode

### DIFF
--- a/cosmoz-omnitable-treenode-column.js
+++ b/cosmoz-omnitable-treenode-column.js
@@ -5,7 +5,6 @@ import '@polymer/paper-spinner/paper-spinner-lite';
 import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { html } from '@polymer/polymer/lib/utils/html-tag';
 
-import { Tree } from '@neovici/cosmoz-tree';
 import { columnMixin } from '@neovici/cosmoz-omnitable/cosmoz-omnitable-column-mixin';
 
 /**
@@ -66,7 +65,7 @@ class CosmozOmnitableTreenodeColumn extends columnMixin(PolymerElement) {
 	static get properties() {
 		return {
 			ownerTree: {
-				type: Tree
+				type: Object
 			},
 
 			/**


### PR DESCRIPTION
Bug: node column is rendered empty if ownerTree is set too late.

It seems that Polymer does not know how to handle data binding for `type: Tree`.