### PR TITLE
feat(treenode-column): left alignment and only deepest node shown

### DIFF
--- a/cosmoz-omnitable-treenode-column.js
+++ b/cosmoz-omnitable-treenode-column.js
@@ -137,8 +137,7 @@ class CosmozOmnitableTreenodeColumn extends columnMixin(PolymerElement) {
 			</style>
 			<cosmoz-treenode
 				hide-from-root=${ifDefined(column.hideFromRoot)}
-				show-max-nodes=${ifDefined(column.showMaxNodes)}
-				no-wrap
+				show-max-nodes=${column.showMaxNodes ? column.showMaxNodes : '1'}
 				key-property=${column.keyProperty}
 				.keyValue=${get(item, column.valuePath)}
 				value-property=${column.valueProperty}
@@ -166,6 +165,7 @@ class CosmozOmnitableTreenodeColumn extends columnMixin(PolymerElement) {
 				active
 			></paper-spinner-lite>`
 		);
+
 		return html` <style>
 				cosmoz-autocomplete.cosmoz-treenode-header-input::part(input-label) {
 					text-transform: var(--cosmoz-omnitable-header-text-transform, none);

--- a/cosmoz-omnitable-treenode-column.js
+++ b/cosmoz-omnitable-treenode-column.js
@@ -65,7 +65,7 @@ class CosmozOmnitableTreenodeColumn extends columnMixin(PolymerElement) {
 			valueProperty: { type: String, value: 'name' },
 			minWidth: { type: String, value: '85px' },
 			hideFromRoot: { type: Number },
-			showMaxNodes: { type: Number, value: '1' },
+			showMaxNodes: { type: Number, value: 1 },
 			limit: { type: Number },
 			keepOpened: { type: Boolean, value: true },
 			keepQuery: { type: Boolean },

--- a/cosmoz-omnitable-treenode-column.js
+++ b/cosmoz-omnitable-treenode-column.js
@@ -65,7 +65,7 @@ class CosmozOmnitableTreenodeColumn extends columnMixin(PolymerElement) {
 			valueProperty: { type: String, value: 'name' },
 			minWidth: { type: String, value: '85px' },
 			hideFromRoot: { type: Number },
-			showMaxNodes: { type: Number },
+			showMaxNodes: { type: Number, value: '1' },
 			limit: { type: Number },
 			keepOpened: { type: Boolean, value: true },
 			keepQuery: { type: Boolean },
@@ -137,7 +137,7 @@ class CosmozOmnitableTreenodeColumn extends columnMixin(PolymerElement) {
 			</style>
 			<cosmoz-treenode
 				hide-from-root=${ifDefined(column.hideFromRoot)}
-				show-max-nodes=${column.showMaxNodes ? column.showMaxNodes : '1'}
+				show-max-nodes=${column.showMaxNodes}
 				key-property=${column.keyProperty}
 				.keyValue=${get(item, column.valuePath)}
 				value-property=${column.valueProperty}


### PR DESCRIPTION
User Story [AB#12784](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/12784) - the new treenode column includes only the deepest node, and visualizes the whole rest of the treenode on hover in a tooltip.

https://github.com/Neovici/cosmoz-omnitable-treenode-column/assets/122988480/9a21deee-36b0-4f0a-a38b-381f9defd6a5

