### PR TITLE
fix: render disabled cosmoz-input in header when disabledFiltering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - beta
   push:
     branches:
       - beta

--- a/cosmoz-omnitable-treenode-column.js
+++ b/cosmoz-omnitable-treenode-column.js
@@ -5,6 +5,7 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { when } from 'lit-html/directives/when.js';
 
 import '@neovici/cosmoz-autocomplete';
+import '@neovici/cosmoz-input';
 import '@neovici/cosmoz-treenode';
 import '@polymer/paper-spinner/paper-spinner-lite';
 
@@ -183,6 +184,9 @@ class CosmozOmnitableTreenodeColumn extends columnMixin(PolymerElement) {
 		setState,
 		source,
 	) {
+		if (disabledFiltering) {
+			return html`<cosmoz-input variant="inline" label=${title} disabled></cosmoz-input>`;
+		}
 		return html` <cosmoz-autocomplete
 			variant="inline"
 			class="cosmoz-treenode-header-input"

--- a/test/disabled-filtering.test.js
+++ b/test/disabled-filtering.test.js
@@ -113,12 +113,15 @@ suite('disabled-filtering', () => {
 			assert.isTrue(nodeColumn.disabledFiltering);
 		});
 
-		test('autocomplete is disabled when disabledFiltering is true', () => {
+		test('renders disabled input when disabledFiltering is true', () => {
 			const headerCell = omnitable.shadowRoot.querySelector(
 				'.header-cell[name="node"]',
 			);
 			const autocomplete = headerCell.querySelector('cosmoz-autocomplete');
-			assert.isTrue(autocomplete.hasAttribute('disabled'));
+			assert.isNull(autocomplete);
+			const input = headerCell.querySelector('cosmoz-input');
+			assert.isTrue(input.hasAttribute('disabled'));
+			assert.equal(input.label, 'Node');
 		});
 
 		test('column without disabled-filtering has enabled autocomplete', () => {
@@ -172,12 +175,15 @@ suite('disabled-filtering', () => {
 			});
 		});
 
-		test('autocomplete is disabled with table-level disabled-filtering', () => {
+		test('renders disabled input with table-level disabled-filtering', () => {
 			const headerCell = omnitable.shadowRoot.querySelector(
 				'.header-cell[name="node"]',
 			);
 			const autocomplete = headerCell.querySelector('cosmoz-autocomplete');
-			assert.isTrue(autocomplete.hasAttribute('disabled'));
+			assert.isNull(autocomplete);
+			const input = headerCell.querySelector('cosmoz-input');
+			assert.isTrue(input.hasAttribute('disabled'));
+			assert.equal(input.label, 'Node');
 		});
 	});
 });


### PR DESCRIPTION
## Problem

When `disabled-filtering` is active on `cosmoz-omnitable`, the treenode column renders a `<cosmoz-autocomplete variant="inline" disabled>` in the header. Unlike the regular column's `<cosmoz-input variant="inline" disabled>`, the autocomplete's floating label doesn't align correctly when disabled with no value — the label stays at `top: 25%` (resting position) instead of floating up, causing misalignment with other column headers.

## Solution

When `disabledFiltering` is true, `renderHeader` now returns a `<cosmoz-input variant="inline" disabled label=${title}>` instead of the full `<cosmoz-autocomplete>`. This matches the visual output of disabled regular column headers exactly, ensuring proper label alignment across all columns.

## Changes

- `cosmoz-omnitable-treenode-column.js`: Early return in `renderHeader` with `<cosmoz-input variant="inline" disabled label=${title}>` when `disabledFiltering` is true; added `@neovici/cosmoz-input` import
- `test/disabled-filtering.test.js`: Updated tests to assert `<cosmoz-input disabled>` is rendered with the correct label instead of `<span>`
- `.github/workflows/ci.yml`: Added `beta` to `pull_request` branches so CI runs on PRs targeting `beta`

## Test Results

All 9 tests pass (Chromium + Firefox).

## Related

- Linear: [FE-954](https://linear.app/neovici/issue/FE-954/) — `inline` mode for cosmoz-omnitable