### PR TITLE
chore: bump beta version to 11.3.0-beta.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@neovici/cosmoz-omnitable-treenode-column": "11.3.0"
+  },
+  "changesets": []
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neovici/cosmoz-omnitable-treenode-column",
-	"version": "11.2.0-beta.2",
+	"version": "11.3.0-beta.0",
 	"description": "A column for cosmoz-omnitable that displays a tree node.",
 	"keywords": [
 		"polymer",
@@ -51,7 +51,8 @@
 	],
 	"dependencies": {
 		"@neovici/cosmoz-autocomplete": "^13.6.0-beta.1",
-		"@neovici/cosmoz-omnitable": "^18.4.0-beta.1",
+		"@neovici/cosmoz-input": "^6.0.0-beta.2",
+		"@neovici/cosmoz-omnitable": "^18.11.0-beta.0",
 		"@neovici/cosmoz-tokens": "^3.4.0",
 		"@neovici/cosmoz-tree": "^3.0.0",
 		"@neovici/cosmoz-treenode": "^6.0.0",


### PR DESCRIPTION
The previous version (11.2.0-beta.2) had lower semver precedence than the stable 11.2.0 release, causing npm to resolve `^11.2.0-beta.2` to 11.2.0 instead of the intended beta.

This manual version bump ensures the beta release has higher precedence than the latest stable.

Changes:
- Bump package version from 11.2.0-beta.2 to 11.3.0-beta.0
- Add `@neovici/cosmoz-input` dependency (`^6.0.0-beta.2`) — the beta code imports it (variant='inline' for disabled filtering header)
- Update `@neovici/cosmoz-omnitable` dependency from `^18.4.0-beta.1` to `^18.11.0-beta.0` for the same versioning fix (requires Neovici/cosmoz-omnitable#1063 to merge first)
- Add `.changeset/pre.json` for proper prerelease versioning