### PR TITLE
chore: finish changesets migration - switch to foundry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - beta
   push:
     branches:
       - beta
@@ -15,5 +16,5 @@ permissions:
 
 jobs:
   build:
-    uses: Neovici/cfg/.github/workflows/forge.yml@master
+    uses: Neovici/cfg/.github/workflows/foundry.yml@master
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,388 +1,323 @@
-## [11.1.0](https://github.com/Neovici/cosmoz-omnitable-treenode-column/compare/v11.0.0...v11.1.0) (2026-04-23)
+## 11.2.0
 
-### Features
+### Minor Changes
 
-* add disabled-filtering attribute support ([#257](https://github.com/Neovici/cosmoz-omnitable-treenode-column/issues/257)) ([b2c1ff4](https://github.com/Neovici/cosmoz-omnitable-treenode-column/commit/b2c1ff40511725f9b6460e0ff082242df0315a46)), closes [Neovici/cosmoz-omnitable#954](https://github.com/Neovici/cosmoz-omnitable/issues/954)
+- Migrate to system design and update storybook (#264)
 
-## [11.0.0](https://github.com/Neovici/cosmoz-omnitable-treenode-column/compare/v10.0.3...v11.0.0) (2026-02-17)
+### Patch Changes
 
-### ⚠ BREAKING CHANGES
+- Render disabled cosmoz-input in header when disabledFiltering (#313)
+- Fix lint error
 
-* requires autocomplete >=12 and omnitable >=18
+_Note: 11.2.0 was accidentally published from the beta branch and included changes not intended for stable release._
 
-### Bug Fixes
+## 11.1.0
 
-* use opened-changed event instead of onFocus for autocomplete v12+ ([#209](https://github.com/Neovici/cosmoz-omnitable-treenode-column/issues/209)) ([1f28e53](https://github.com/Neovici/cosmoz-omnitable-treenode-column/commit/1f28e533272bc36e79fd1f85d97965cb03ad8ce6))
+### Minor Changes
 
-## [10.0.3](https://github.com/Neovici/cosmoz-omnitable-treenode-column/compare/v10.0.2...v10.0.3) (2026-02-17)
+- Add disabled-filtering attribute support (#257)
 
-### Bug Fixes
+## 11.0.0
 
-* **deps:** support cosmoz-autocomplete v9–v13 ([#208](https://github.com/Neovici/cosmoz-omnitable-treenode-column/issues/208)) ([5e5785d](https://github.com/Neovici/cosmoz-omnitable-treenode-column/commit/5e5785dc79a80a05217adacd6c0a8a7d3ea9ba5e))
+### ⚠️ BREAKING CHANGES
 
-## [10.0.2](https://github.com/Neovici/cosmoz-omnitable-treenode-column/compare/v10.0.1...v10.0.2) (2026-01-29)
+- Requires autocomplete >=12 and omnitable >=18
 
-### Bug Fixes
+### Patch Changes
 
-* support cosmoz-omnitable v17 ([#192](https://github.com/Neovici/cosmoz-omnitable-treenode-column/issues/192)) ([026a532](https://github.com/Neovici/cosmoz-omnitable-treenode-column/commit/026a532f375fe662842e04d73cab72c95dbc0975))
+- Use opened-changed event instead of onFocus for autocomplete v12+ (#209)
 
-## [10.0.1](https://github.com/Neovici/cosmoz-omnitable-treenode-column/compare/v10.0.0...v10.0.1) (2026-01-28)
+## 10.0.3
 
-### Bug Fixes
+### Patch Changes
 
-* repository URL case sensitivity ([214f356](https://github.com/Neovici/cosmoz-omnitable-treenode-column/commit/214f356fc9c54e017e3e7a5a34430693f15bff8d))
+- Support cosmoz-autocomplete v9–v13 (#208)
 
-## [10.0.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v9.1.3...v10.0.0) (2025-12-02)
+## 10.0.2
 
-### ⚠ BREAKING CHANGES
+### Patch Changes
 
-* **deps:** Upgrade to latest omnitable
+- Support cosmoz-omnitable v17 (#192)
 
-* chore: cleanup deps
+## 10.0.1
 
-* chore: lint fix
+### Patch Changes
 
-### Features
+- Fix repository URL case sensitivity
 
-* **deps:** upgrade to latest upgrade-omnitable ([#153](https://github.com/neovici/cosmoz-omnitable-treenode-column/issues/153)) ([61ec623](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/61ec6238261cfcac17cbf19d1d72d2267bcd69a2))
+## 10.0.0
 
-## [9.1.3](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v9.1.2...v9.1.3) (2025-10-31)
+### ⚠️ BREAKING CHANGES
 
-### Bug Fixes
+- Upgrade to latest omnitable
 
-* check compatibility with omnitable@15 ([acb74e7](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/acb74e75f0bb3b8016e16decdaf875d27298efa8))
+### Minor Changes
 
-## [9.1.2](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v9.1.1...v9.1.2) (2025-10-08)
+- Upgrade to latest upgrade-omnitable (#153)
 
-### Bug Fixes
+## 9.1.3
 
-* cannot import from latest omnitable ([22d144b](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/22d144b0da56ffcd3e847ee398996952e13252bc))
+### Patch Changes
 
-## [9.1.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v9.1.0...v9.1.1) (2025-08-04)
+- Check compatibility with omnitable@15
 
-### Bug Fixes
+## 9.1.2
 
-* automerge workflow ([0b6c9b0](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/0b6c9b089d18dcdcb16c8a3737dbd6de3aa88d01))
+### Patch Changes
 
-## [9.1.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v9.0.1...v9.1.0) (2025-07-21)
+- Fix cannot import from latest omnitable
 
-### Features
+## 9.1.1
 
-* new automerge workflow ([75411aa](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/75411aabba8d5b539902bfe8dea82ddfc20a948d))
+### Patch Changes
 
-## [9.0.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v9.0.0...v9.0.1) (2025-03-25)
+- Fix automerge workflow
 
-### Bug Fixes
+## 9.1.0
 
-* commitlint config and update ([3a8124e](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/3a8124e764315902a0cfbb9d4f33b5419862e026))
+### Minor Changes
 
-## [9.0.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v8.1.1...v9.0.0) (2025-01-17)
+- New automerge workflow
 
-### ⚠ BREAKING CHANGES
+## 9.0.1
 
-* Update cosmoz-dropdown
+### Patch Changes
 
-### Features
+- Fix commitlint config and update
 
-* update cosmoz-dropdown ([ceaba15](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/ceaba154c4d7185a940a502549c31e2c6cc86ca5))
+## 9.0.0
 
-## [8.1.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v8.1.0...v8.1.1) (2024-11-20)
+### ⚠️ BREAKING CHANGES
 
-### Bug Fixes
+- Update cosmoz-dropdown
 
-* **deps:** upgrade cosmoz-autocomplete ([647bf0f](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/647bf0fb93b5385fdc955b8689e00709534d8a17))
+### Minor Changes
 
-## [8.1.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v8.0.0...v8.1.0) (2024-09-12)
+- Update cosmoz-dropdown
 
-### Features
+## 8.1.1
 
-* implement values fn ([220ab6c](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/220ab6c0deb62fb833c8e67258a4a59e77aaa834))
+### Patch Changes
 
-## [8.0.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.8.0...v8.0.0) (2024-01-13)
+- Upgrade cosmoz-autocomplete
 
+## 8.1.0
 
-### ⚠ BREAKING CHANGES
+### Minor Changes
 
-* Update deps to @pionjs/pion
+- Implement values fn
 
-### Features
+## 8.0.0
 
-* update to pion ([330a2d6](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/330a2d6b523978ed32bb9a097c9a557215194d1e))
+### ⚠️ BREAKING CHANGES
 
-## [7.8.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.7.0...v7.8.0) (2023-11-15)
+- Update deps to @pionjs/pion
 
+### Minor Changes
 
-### Features
+- Update to pion
 
-* **treenode-column:** left alignment and only deepest node shown ([#102](https://github.com/neovici/cosmoz-omnitable-treenode-column/issues/102)) ([f8ef088](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/f8ef088c6e24ff8e819bcd576aa28dcbb7bb5a16)), closes [AB#12784](https://github.com/neovici/AB/issues/12784)
+## 7.8.0
 
-## [7.7.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.6.0...v7.7.0) (2023-06-13)
+### Minor Changes
 
+- Left alignment and only deepest node shown (#102)
 
-### Features
+## 7.7.0
 
-* **treenode-column:** add keep-opened & keep-query support ([1504d90](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/1504d9089f7c6cc10f20584582bdc5273aa9ece6))
+### Minor Changes
 
-## [7.6.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.5.0...v7.6.0) (2023-04-28)
+- Add keep-opened & keep-query support
 
+## 7.6.0
 
-### Features
+### Minor Changes
 
-* update autocomplete ([f950127](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/f95012732c50f480f757d55eef2e3ba0e9a760b7))
+- Update autocomplete
 
-## [7.5.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.4.0...v7.5.0) (2023-04-25)
+## 7.5.0
 
+### Minor Changes
 
-### Features
+- Cleanup README
 
-* cleanup README ([dcbd35e](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/dcbd35e0eec69bac77d51613eceab7c898435d32))
+## 7.4.0
 
-## [7.4.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.3.0...v7.4.0) (2023-04-25)
+### Minor Changes
 
+- Adjust workflow
+- Allow autocomplete v6
 
-### Features
+### Patch Changes
 
-* adjust workflow ([393d143](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/393d143648117176554ec94fb966c117f6ac7bb9))
-* allow autocomplete v6 ([cb8cc34](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/cb8cc34395c4bb6c44fa7a9b08b9d7f30d927b97))
+- Upgrade cosmoz-dropdown
 
+## 7.3.0
 
-### Bug Fixes
+### Minor Changes
 
-* upgrade cosmoz-dropdown ([e3a9a9a](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/e3a9a9a870ed70cae6d836fd6636b9884cda170d))
+- Adjusted font weight for header
 
-## [7.3.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.2.1...v7.3.0) (2023-04-05)
+## 7.2.1
 
+### Patch Changes
 
-### Features
+- Fix limit, hideFromRoot, showMaxNodes properties were not set
 
-* adjusted font weight for header ([5985c48](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/5985c48cb1ed37d43a1f78e852d71707d3e299f6))
+## 7.2.0
 
-## [7.2.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.2.0...v7.2.1) (2023-03-24)
+### Minor Changes
 
+- Multi value filtering on several nodes (#92)
 
-### Bug Fixes
+## 7.1.4
 
-* **limit,hideFromRoot,showMaxNodes:** properties were not set ([5c535d0](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/5c535d09d5a6672ec9956c2a3865b323142e6e8a))
+### Patch Changes
 
-## [7.2.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.1.4...v7.2.0) (2023-03-09)
+- Fix memoize imported from utils in omnitable treenode
 
+## 7.1.3
 
-### Features
+### Patch Changes
 
-* **multi value filtering:** filtering on several nodes ([#92](https://github.com/neovici/cosmoz-omnitable-treenode-column/issues/92)) ([50ac57f](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/50ac57f15437bf49da4cb6b30c3ad4b7de2b54ab))
+- Fix cosmoz-autocomplete version
 
-## [7.1.4](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.1.3...v7.1.4) (2023-02-14)
+## 7.1.2
 
+### Patch Changes
 
-### Bug Fixes
+- Fix use autocomplete
 
-* memoize imported from utils in omnitable treenode ([cdcc596](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/cdcc596a8ab0a4ccc766efbd229f39e389b61558))
+## 7.1.1
 
-## [7.1.3](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.1.2...v7.1.3) (2023-01-07)
+### Patch Changes
 
+- Fix lint
+- Restore query notification
 
-### Bug Fixes
+## 7.1.0
 
-* **deps:** correct cosmoz-autocomplete version ([00eb5b6](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/00eb5b68f86b37e10fe18db37af94e106e9e9753))
+### Minor Changes
 
-## [7.1.2](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.1.1...v7.1.2) (2022-11-13)
+- Update deps
 
+## 7.0.0
 
-### Bug Fixes
+### ⚠️ BREAKING CHANGES
 
-* use autocomplete ([fc192c2](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/fc192c25eadef42a0d659fe0ca4e4383b187d2f2))
+- Upgrade omnitable, input, dropdown & utils deps
 
-## [7.1.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.1.0...v7.1.1) (2022-10-04)
+### Minor Changes
 
+- Upgrade deps (#68778f6)
 
-### Bug Fixes
+## 6.0.1
 
-* **chore:**  lint ([0e6d9a8](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/0e6d9a88de3c7a45cfa7162cf204ef7f3e3940a1))
-* restore query notification ([81ea712](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/81ea7121b33b5e6fc1467a26889c360e51adfd03))
+### Patch Changes
 
-## [7.1.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v7.0.0...v7.1.0) (2022-09-15)
+- Update deps
 
+## 6.0.0
 
-### Features
+### ⚠️ BREAKING CHANGES
 
-* update deps ([e475c2e](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/e475c2e9725f3ce72a778f884f4c5219bce1a739))
+- Upgrade to lit@^2 and haunted@^5
 
-## [7.0.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v6.0.1...v7.0.0) (2022-07-20)
+### Minor Changes
 
+- Upgrade to lit@^2
 
-### ⚠ BREAKING CHANGES
+## 5.2.0
 
-* **deps:** Upgrade omnitable, input, dropdown & utils deps.
+### Minor Changes
 
-### Features
+- Compatible with omnitable v9
 
-* **deps:** upgrade ([68778f6](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/68778f6d4f028fd0257d135444837ed67582cf16))
+## 5.1.0
 
-## [6.0.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v6.0.0...v6.0.1) (2022-06-23)
+### Minor Changes
 
+- Update cosmoz-autocomplete
 
-### Bug Fixes
+## 5.0.0
 
-* **deps:** update ([f9f8d1a](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/f9f8d1a22c935d0ce0b41cd1e8bdd1fa3e1b997e))
+### ⚠️ BREAKING CHANGES
 
-## [6.0.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v5.2.0...v6.0.0) (2022-06-22)
+- The column uses the updated omnitable column API
 
+### Minor Changes
 
-### ⚠ BREAKING CHANGES
+- Upgrade to omnitable v8
 
-* Upgrade to lit@^2 and haunted@^5
+### Patch Changes
 
-### Features
+- Fix error in computeSource
+- Fix integration with omnitable search helper and useOTS
+- Fix match new getComparableValue signature
+- Fix upgrade cosmoz-omnitable@v8
+- Fix upgrade cosmoz-treenode
 
-* upgrade to lit@^2 ([5bebbe4](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/5bebbe45500b234d35531cfff07aeb7c7aafdce3))
+## 4.0.1
 
-## [6.0.0-beta.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v5.2.0...v6.0.0-beta.1) (2022-06-17)
+### Patch Changes
 
+- Upgrade to omnitable v6
 
-### ⚠ BREAKING CHANGES
+## 4.0.0
 
-* Upgrade to lit@^2 and haunted@^5
+### ⚠️ BREAKING CHANGES
 
-### Features
+- Drop compatibility with omnitable v4
 
-* upgrade to lit@^2 ([5bebbe4](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/5bebbe45500b234d35531cfff07aeb7c7aafdce3))
+### Minor Changes
 
-## [5.2.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v5.1.0...v5.2.0) (2022-06-06)
+- Upgrade to omnitable v5
 
+## 3.2.4
 
-### Features
+### Patch Changes
 
-* compatible with omnitable v9 ([804bd4e](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/804bd4eff3ff7dc3b6f1aac717fdeb0eec9c5ae3))
+- Upgrade cosmoz-omnitable
 
-## [5.1.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v5.0.0...v5.1.0) (2022-03-31)
+## 3.2.3
 
+### Patch Changes
 
-### Features
+- Fix owner-tree updates not sent to cosmoz-treenode
 
-* **deps:** update cosmoz-autocomplete ([f9ad816](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/f9ad816e35290d311bd7166561a4aac6eb78adbe))
+## 3.2.2
 
-## [5.0.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v4.0.1...v5.0.0) (2021-12-17)
+### Patch Changes
 
+- Fix restores internal suggestions filtering
 
-### ⚠ BREAKING CHANGES
+## 3.2.1
 
-* the column uses the updated omnitable column API
+### Patch Changes
 
-### Features
+- Fix filter and UI
 
-* upgrade to omnitable v8 ([5a944c6](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/5a944c69aa830557652cc18db7a5b9a34291942f))
+## 3.2.0
 
+### Minor Changes
 
-### Bug Fixes
+- Replace paper-autocomplete with cosmoz-autocomplete
+- Upgrade repo
 
-* error in computeSource ([d7c7440](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/d7c7440ff520b73c26588624d9875324afacb810))
-* integration with omnitable search helper and useOTS ([e27fb00](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/e27fb00026b116d0c005550b2e2032f6bca19aae))
-* match new getComparableValue signature ([f48d5f3](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/f48d5f3122aa8594a5ba59913323956cb8e4d80d))
-* upgrade cosmoz-omnitable@v8 ([68ed8bb](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/68ed8bb78638861f6dc9b9d1c0c24b825af0d24f))
-* upgrade cosmoz-treenode ([a89a399](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/a89a3991522551945081d84d5e7d37409481c479))
+## 3.1.2
 
-## [5.0.0-beta.4](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v5.0.0-beta.3...v5.0.0-beta.4) (2021-12-17)
+### Patch Changes
 
+- Fix error when ownerTree is undefined
 
-### Bug Fixes
+## 3.1.1
 
-* upgrade cosmoz-omnitable@v8 ([68ed8bb](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/68ed8bb78638861f6dc9b9d1c0c24b825af0d24f))
+### Patch Changes
 
-## [5.0.0-beta.3](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v5.0.0-beta.2...v5.0.0-beta.3) (2021-12-15)
+- Adopt semantic release
 
+## 3.1.0
 
-### Bug Fixes
+### Minor Changes
 
-* integration with omnitable search helper and useOTS ([e27fb00](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/e27fb00026b116d0c005550b2e2032f6bca19aae))
-* upgrade cosmoz-treenode ([a89a399](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/a89a3991522551945081d84d5e7d37409481c479))
-
-## [5.0.0-beta.2](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v5.0.0-beta.1...v5.0.0-beta.2) (2021-12-13)
-
-
-### Bug Fixes
-
-* match new getComparableValue signature ([f48d5f3](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/f48d5f3122aa8594a5ba59913323956cb8e4d80d))
-
-## [5.0.0-beta.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v4.0.1...v5.0.0-beta.1) (2021-12-07)
-
-
-### ⚠ BREAKING CHANGES
-
-* the column uses the updated omnitable column API
-
-### Features
-
-* upgrade to omnitable v8 ([5a944c6](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/5a944c69aa830557652cc18db7a5b9a34291942f))
-
-
-### Bug Fixes
-
-* error in computeSource ([d7c7440](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/d7c7440ff520b73c26588624d9875324afacb810))
-
-### [4.0.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v4.0.0...v4.0.1) (2021-05-05)
-
-
-### Bug Fixes
-
-* upgrade to omnitable v6 ([1eb91a7](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/1eb91a7e20bacbb67b324c00497b1aaef4e8ea64))
-
-## [4.0.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v3.2.4...v4.0.0) (2021-03-24)
-
-
-### ⚠ BREAKING CHANGES
-
-* drop compatibility with omnitable v4
-
-### Features
-
-* upgrade to omnitable v5 ([932de7f](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/932de7fcb6de378ccb6e994bb1f3c42b7d94eccc))
-
-### [3.2.4](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v3.2.3...v3.2.4) (2020-10-15)
-
-
-### Bug Fixes
-
-* upgrade cosmoz-omnitable ([88b5dd0](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/88b5dd08f987a7f32972b644d48a742b373db557))
-
-### [3.2.3](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v3.2.2...v3.2.3) (2020-10-07)
-
-
-### Bug Fixes
-
-* **owner-tree:** owner-tree updates are not sent to the cosmoz-treenode ([cbddf4d](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/cbddf4ded452da15b31384debeb5d936115a6f34))
-
-### [3.2.2](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v3.2.1...v3.2.2) (2020-06-03)
-
-
-### Bug Fixes
-
-* restores internal suggestions filtering ([df4d129](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/df4d1297e83160883962367a233fbfba45fb3c33))
-
-### [3.2.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v3.2.0...v3.2.1) (2020-05-07)
-
-
-### Bug Fixes
-
-* fixes filter and ui ([0125843](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/0125843d3241ee70db58c5a7177113b16c8607aa))
-
-## [3.2.0](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v3.1.2...v3.2.0) (2020-05-07)
-
-
-### Features
-
-* replaces paper-autocomplete with cosmoz-autocomplete ([d9581dd](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/d9581dd3435824d4d5cbb627333b22b1cce31b21))
-* upgrade repo ([b1932f2](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/b1932f21187ef158f8bdbe5a8798c73f4289ac1a))
-
-## [3.1.2](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v3.1.1...v3.1.2) (2019-10-15)
-
-
-### Bug Fixes
-
-* error when ownerTree is undefined ([e58a844](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/e58a844788cb048f6ebc11ed780a758a851786ca))
-
-## [3.1.1](https://github.com/neovici/cosmoz-omnitable-treenode-column/compare/v3.1.0...v3.1.1) (2019-10-10)
-
-
-### Bug Fixes
-
-* **ci:** adopt semantic release ([3c89664](https://github.com/neovici/cosmoz-omnitable-treenode-column/commit/3c89664db14a55239d11de9ba4a65a93e2fa40ce))
+- Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@neovici/cosmoz-omnitable-treenode-column",
-	"version": "11.1.0",
+	"version": "11.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@neovici/cosmoz-omnitable-treenode-column",
-			"version": "11.1.0",
+			"version": "11.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@neovici/cosmoz-autocomplete": "^12.0.0 || ^13.0.0",
@@ -6969,13 +6969,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/array-ify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/array-includes": {
 			"version": "3.1.9",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
@@ -8187,17 +8180,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/compare-func": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-ify": "^1.0.0",
-				"dot-prop": "^5.1.0"
-			}
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8249,16 +8231,16 @@
 			}
 		},
 		"node_modules/conventional-changelog-conventionalcommits": {
-			"version": "9.3.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
-			"integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+			"integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"compare-func": "^2.0.0"
+				"@conventional-changelog/template": "^1.2.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=22"
 			}
 		},
 		"node_modules/conventional-commits-parser": {
@@ -8790,19 +8772,6 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/dot-prop": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-obj": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -11537,16 +11506,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/is-plain-obj": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neovici/cosmoz-omnitable-treenode-column",
-	"version": "11.1.0",
+	"version": "11.2.0",
 	"description": "A column for cosmoz-omnitable that displays a tree node.",
 	"keywords": [
 		"polymer",
@@ -30,9 +30,7 @@
 		"storybook:build": "build-storybook",
 		"storybook:deploy": "storybook-to-ghpages",
 		"prepare": "husky",
-		"changeset": "changeset",
-		"version": "changeset version",
-		"release": "npm run build && changeset publish"
+		"changeset": "changeset"
 	},
 	"publishConfig": {
 		"access": "public"
@@ -63,8 +61,5 @@
 		"lint-staged": "^17.0.4",
 		"sinon": "^22.0.0",
 		"typescript-eslint": "^8.48.0"
-	},
-	"overrides": {
-		"conventional-changelog-conventionalcommits": ">= 8.0.0"
 	}
 }


### PR DESCRIPTION
## Summary

Finish the changesets migration by switching to the foundry CI workflow and cleaning up semantic-release artifacts.

### Changes

- **CI workflow**: Switch from `forge.yml` to `foundry.yml` which uses `changesets/action@v1` instead of `semantic-release`
- **CI workflow**: Add `beta` to `pull_request.branches` for prerelease CI support
- **package.json**: Set version to `11.2.0` (sync with npm latest — this version was accidentally published from beta)
- **package.json**: Remove `version` and `release` scripts (foundry handles these via changesets action)
- **package.json**: Remove `overrides` block (semantic-release artifact)
- **CHANGELOG.md**: Convert entire history from semantic-release format to changesets format
- **CHANGELOG.md**: Document 11.2.0 as accidentally published from beta
- **Pending changeset**: `.changeset/migrate-to-changesets.md` will bump to `11.3.0` on merge

### Post-merge steps

1. Merge this PR → foundry creates a **Version Packages** PR (bumps to 11.3.0)
2. Merge the Version Packages PR → foundry publishes `11.3.0` to npm
3. Merge master into beta, enter changesets prerelease mode (`npx changeset pre enter beta`)
4. Create a minor changeset for beta features → CI publishes `11.4.0-beta.0`

### Why 11.2.0?

Version 11.2.0 was accidentally published from the beta branch via semantic-release (no `v11.2.0` tag exists on master). Setting the package version to 11.2.0 aligns with npm and allows the pending changeset to correctly bump to 11.3.0.